### PR TITLE
fix FindFirst queries and password compare on login

### DIFF
--- a/src/handlers/health.go
+++ b/src/handlers/health.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"github.com/Gamify-IT/login-backend/src/gen/db"
 	"github.com/Gamify-IT/login-backend/src/gen/models"
 	"github.com/Gamify-IT/login-backend/src/gen/restapi/operations/health"
@@ -13,7 +14,7 @@ func healthHandler(client *db.PrismaClient) health.GetHealthHandlerFunc {
 
 		// Check if DB is alive by performing any select
 		_, err := client.User.FindFirst(db.User.ID.Contains("")).Exec(params.HTTPRequest.Context())
-		if err != nil {
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
 			return health.NewGetHealthServiceUnavailable().WithPayload(&models.Health{
 				Status: "DOWN",
 			})

--- a/src/handlers/register.go
+++ b/src/handlers/register.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"github.com/Gamify-IT/login-backend/src/gen/db"
 	"github.com/Gamify-IT/login-backend/src/gen/models"
 	"github.com/Gamify-IT/login-backend/src/gen/restapi/operations/register"
@@ -15,29 +16,37 @@ func registerUser(client *db.PrismaClient) register.PostRegisterHandlerFunc {
 		email := params.Body.Email
 		password := params.Body.Password
 
-		hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(*password), bcrypt.DefaultCost)
-
-		existingUser, err := client.User.FindFirst(db.User.Name.Equals(*username)).Exec(params.HTTPRequest.Context())
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(*password), bcrypt.DefaultCost)
 
 		if err != nil {
 			return register.NewPostRegisterInternalServerError().WithPayload(&models.Error{
-				Message: "An error occurred while adding the user to the database",
+				Message: "An error occurred while encrypting your password",
 			})
 		}
 
-		if existingUser != nil {
+		existingUser, err := client.User.FindFirst(db.User.Name.Equals(*username)).Exec(params.HTTPRequest.Context())
+
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
+			return register.NewPostRegisterInternalServerError().WithPayload(&models.Error{
+				Message: "An error occurred while adding the user to the database",
+			})
+		} else if existingUser != nil {
 			return register.NewPostRegisterBadRequest().WithPayload(&models.Error{
 				Message: "Username already in use",
 			})
 		}
 
-		client.User.CreateOne(db.User.Name.Set(*username), db.User.Email.Set(*email), db.User.PasswordHash.Set(string(hashedPassword)))
+		client.User.CreateOne(db.User.Name.Set(*username), db.User.Email.Set(*email), db.User.PasswordHash.Set(string(hashedPassword))).Exec(params.HTTPRequest.Context())
 
 		createdUser, err := client.User.FindFirst(db.User.Name.Equals(*username)).Exec(params.HTTPRequest.Context())
 
-		if err != nil {
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
 			return register.NewPostRegisterInternalServerError().WithPayload(&models.Error{
 				Message: "An error occurred while adding the user to the database",
+			})
+		} else if errors.Is(err, db.ErrNotFound) {
+			return register.NewPostRegisterInternalServerError().WithPayload(&models.Error{
+				Message: "An error occurred while fetching current added user from the database",
 			})
 		}
 
@@ -45,6 +54,5 @@ func registerUser(client *db.PrismaClient) register.PostRegisterHandlerFunc {
 			ID:   createdUser.ID,
 			Name: createdUser.Name,
 		})
-
 	})
 }

--- a/src/handlers/register.go
+++ b/src/handlers/register.go
@@ -36,17 +36,11 @@ func registerUser(client *db.PrismaClient) register.PostRegisterHandlerFunc {
 			})
 		}
 
-		client.User.CreateOne(db.User.Name.Set(*username), db.User.Email.Set(*email), db.User.PasswordHash.Set(string(hashedPassword))).Exec(params.HTTPRequest.Context())
+		createdUser, err := client.User.CreateOne(db.User.Name.Set(*username), db.User.Email.Set(*email), db.User.PasswordHash.Set(string(hashedPassword))).Exec(params.HTTPRequest.Context())
 
-		createdUser, err := client.User.FindFirst(db.User.Name.Equals(*username)).Exec(params.HTTPRequest.Context())
-
-		if err != nil && !errors.Is(err, db.ErrNotFound) {
+		if err != nil {
 			return register.NewPostRegisterInternalServerError().WithPayload(&models.Error{
 				Message: "An error occurred while adding the user to the database",
-			})
-		} else if errors.Is(err, db.ErrNotFound) {
-			return register.NewPostRegisterInternalServerError().WithPayload(&models.Error{
-				Message: "An error occurred while fetching current added user from the database",
 			})
 		}
 


### PR DESCRIPTION
Queries with FindFirst did not work as expected. When there is no entry for the query, it will return an error. All errors are now catched right. Also the password compare on login is now implemented correctly.